### PR TITLE
Fixed zip package download (issue #1)

### DIFF
--- a/davutils.py
+++ b/davutils.py
@@ -216,7 +216,7 @@ def add_to_zip_recursively(zipobj, real_path, root_dir, check_read):
         root_dir += '/'
     
     for path in search_directory(real_path):
-        if not os.path.isdir(path) or not check_read(path):
+        if os.path.isdir(path) or not check_read(path):
             continue
         
         assert path[:len(root_dir)] == root_dir


### PR DESCRIPTION
Issue was inverted condition in add_to_zip_recursively since it threw out everything that was not a directory, like files. Fixes  PetteriAimonen/easydav#1